### PR TITLE
feat(endpoints): Thirdparty inbound and outbound authorizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "start:outbound": "ts-node --project ./tsconfig.json --files --require tsconfig-paths/register ./src/cli.ts outbound",
     "dev": "nodemon --watch 'src/**/*.ts' --exec 'ts-node' src/cli.ts",
     "test": "npm run test:unit",
-    "test:bdd": "jest --config './jest.bdd.config.js' --testMatch '**/test/step-definitions/**/*.step.ts'",
+    "test:bdd": "jest --config './jest.bdd.config.js' --runInBand --testMatch '**/test/step-definitions/**/*.step.ts'",
     "test:coverage": "jest --coverage  --testMatch '**/test/unit/**/*.(test|spec).ts'",
     "test:coverage-check": "jest --coverage --testMatch '**/test/unit/**/*.(test|spec).ts'",
     "test:integration": "jest --config './jest.integration.config.js' --testMatch '**/test/integration/**/*.(test|spec).ts'",

--- a/src/handlers/inbound/index.ts
+++ b/src/handlers/inbound/index.ts
@@ -23,14 +23,17 @@
 
  - Paweł Marzec <pawel.marzec@modusbox.com>
  - Kevin Leyow <kevin.leyow@modusbox.com>
-
+ - Sridhar Voruganti <sridhar.voruganti@modusbox.com>
+ 
  --------------
  ******/
 import Hello from './hello'
 import ThirdpartyRequestsTransactions from './thirdpartyRequests/transactions'
 import InboundAuthorizations from './authorizations'
+import ThirdpartyAuthorizations from './thirdpartyRequests/transactions/{ID}/authorizations'
 export default {
   HelloGet: Hello.get,
   ThirdpartyRequestsTransactionsPost: ThirdpartyRequestsTransactions.post,
-  InboundAuthorizationsIDPutResponse: InboundAuthorizations.put
+  InboundAuthorizationsIDPutResponse: InboundAuthorizations.put,
+  UpdateThirdpartyAuthorization: ThirdpartyAuthorizations.put
 }

--- a/src/handlers/inbound/thirdpartyRequests/transactions/{ID}/authorizations.ts
+++ b/src/handlers/inbound/thirdpartyRequests/transactions/{ID}/authorizations.ts
@@ -1,0 +1,46 @@
+/*****
+ License
+ --------------
+ Copyright © 2020 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the 'License') and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ - Sridhar Voruganti <sridhar.voruganti@modusbox.com>
+ --------------
+ ******/
+
+import { Request, ResponseObject } from '@hapi/hapi'
+import { Message } from '~/shared/pub-sub'
+import { StateResponseToolkit } from '~/server/plugins/state'
+import { InboundThirdpartyAuthorizationsPutRequest } from '~/models/thirdparty.authorizations.interface'
+import { OutboundThirdpartyAuthorizationsModel } from '~/models/outbound/thirdparty.authorizations.model'
+
+/**
+ * Handles a inbound PUT /thirdpartyRequests/transactions/{ID} request
+ */
+async function put (_context: any, request: Request, h: StateResponseToolkit): Promise<ResponseObject> {
+  const transactionRequest = request.payload as InboundThirdpartyAuthorizationsPutRequest
+  const transactionRequestId: string = request.params.ID
+  const channel = OutboundThirdpartyAuthorizationsModel.notificationChannel(transactionRequestId)
+  const pubSub = h.getPubSub()
+  // don't await on promise to resolve, let finish publish in background
+  pubSub.publish(channel, transactionRequest as unknown as Message)
+  return h.response({}).code(200)
+}
+
+export default {
+  put
+}

--- a/src/handlers/outbound/index.ts
+++ b/src/handlers/outbound/index.ts
@@ -22,12 +22,15 @@
  - Name Surname <name.surname@gatesfoundation.com>
 
  - Paweł Marzec <pawel.marzec@modusbox.com>
+ - Sridhar Voruganti <sridhar.voruganti@modusbox.com>
 
  --------------
  ******/
 import Hello from './hello'
 import Authorizations from './authorizations'
+import ThirdpartyAuthorizations from './thirdpartyRequests/transactions/{ID}/authorizations'
 export default {
   OutboundAuthorizationsPost: Authorizations.post,
+  VerifyThirdPartyAuthorization: ThirdpartyAuthorizations.post,
   HelloGet: Hello.get
 }

--- a/src/handlers/outbound/thirdpartyRequests/transactions/{ID}/authorizations.ts
+++ b/src/handlers/outbound/thirdpartyRequests/transactions/{ID}/authorizations.ts
@@ -1,0 +1,68 @@
+/*****
+ License
+ --------------
+ Copyright © 2020 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the 'License') and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ - Sridhar Voruganti <sridhar.voruganti@modusbox.com>
+ --------------
+ ******/
+
+import { StateResponseToolkit } from '~/server/plugins/state'
+import { Request, ResponseObject } from '@hapi/hapi'
+import {
+  OutboundThirdpartyAuthorizationsPostRequest,
+  OutboundThirdpartyAuthorizationsData,
+  OutboundThirdpartyAuthorizationsModelConfig,
+  OutboundThirdpartyAuthorizationsPostResponse
+} from '~/models/thirdparty.authorizations.interface'
+import {
+  OutboundThirdpartyAuthorizationsModel,
+  create
+} from '~/models/outbound/thirdparty.authorizations.model'
+
+/**
+ * Handles outbound POST /thirdpartyRequests/transactions/{ID}/authorizations request
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function post (_context: any, request: Request, h: StateResponseToolkit): Promise<ResponseObject> {
+
+  const authRequest = request.payload as OutboundThirdpartyAuthorizationsPostRequest
+  const transactionRequestId: string = request.params.ID
+  // prepare config
+  const data: OutboundThirdpartyAuthorizationsData = {
+    toParticipantId: authRequest.toParticipantId,
+    request: authRequest,
+    currentState: 'start'
+  }
+  const config: OutboundThirdpartyAuthorizationsModelConfig = {
+    key: transactionRequestId,
+    kvs: h.getKVS(),
+    logger: h.getLogger(),
+    pubSub: h.getPubSub(),
+    requests: h.getThirdpartyRequests()
+  }
+
+  const model: OutboundThirdpartyAuthorizationsModel = await create(data, config)
+  const result = await model.run();
+  // TODO: handle errors
+  return h.response(result as OutboundThirdpartyAuthorizationsPostResponse).code(200)
+}
+
+export default {
+  post
+}

--- a/src/interface/api-inbound-template.yaml
+++ b/src/interface/api-inbound-template.yaml
@@ -53,7 +53,6 @@ paths:
           $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/501'
         '503':
           $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/503'
-
   /health:
     get:
       tags:
@@ -203,6 +202,60 @@ paths:
       operationId: ThirdpartyRequestsTransactionsPost
       summary: example get
       description: The HTTP request GET /hello is used to return some example json.
+  /thirdpartyRequests/transactions/{ID}/authorizations:
+    put:
+      operationId: UpdateThirdpartyAuthorization
+      summary: UpdateThirdpartyAuthorization
+      description: |
+        The HTTP request `PUT /thirdpartyRequests/transactions/{id}/authorizations` is used by the auth-service to update a thirdparty authorization after successful validation.
+        For an unsuccessful authorization result, the `PUT /thirdpartyRequests/transactions/{id}/authorizations/error` will be called by the auth-service, instead of this endpoint.
+      parameters:
+        #Path
+        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/ID.yaml'
+        #Headers
+        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/Content-Length.yaml'
+        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/Content-Type.yaml'
+        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/Date.yaml'
+        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/X-Forwarded-For.yaml'
+        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-Source.yaml'
+        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-Destination.yaml'
+        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-Encryption.yaml'
+        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-Signature.yaml'
+        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-URI.yaml'
+        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-HTTP-Method.yaml'
+      requestBody:
+        description: The thirdparty authorization details to update
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateThirdpartyAuthorizationRequest'
+            example:
+              challenge: '<QuoteResponse object>'
+              value: '<base64 encoded binary - the signed quote response object>'
+              consentId: '8d34f91d-d078-4077-8263-2c0498dhbjr'
+              sourceAccountId: 'dfspa.alice.1234'
+              status: 'VERIFIED'
+      responses:
+        200:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/200'
+        400:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/400'
+        401:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/401'
+        403:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/403'
+        404:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/404'
+        405:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/405'
+        406:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/406'
+        501:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/501'
+        503:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/503'
+
 components:
   responses:
     InboundAuthorizationsIDPutResponse:
@@ -286,3 +339,36 @@ components:
         - amount
         - transactionType
         - expiration
+    UpdateThirdpartyAuthorizationRequest:
+      title: UpdateThirdpartyAuthorizationRequest
+      type: object
+      description: The object sent in the PUT /thirdpartyRequests/transactions/{id}/authorizations request.
+      properties:
+        challenge:
+          type: string
+          description: The original Challenge Object as a JSON string
+        value:
+          allOf:
+            - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/schemas/BinaryString.yaml'
+          description: 'Base64 encoded binary string - the signed challenge'
+        consentId:
+          allOf:
+            - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/schemas/CorrelationId.yaml'
+          description: >
+            Common ID between the PISP and FSP for the Consent object
+            This tells DFSP and auth-service which constent allows the PISP to initiate transaction.
+        sourceAccountId:
+          allOf:
+            - $ref: '#/components/schemas/AccountId'
+          description: DFSP specific account identifiers, e.g. `dfspa.alice.1234`
+        status:
+          type: string
+          enum:
+            - VERIFIED
+          description: The status of the authorization. This value must be `VERIFIED` for a PUT request
+      required:
+        - challenge
+        - value
+        - consentId
+        - sourceAccountId
+        - status

--- a/src/interface/api-inbound.yaml
+++ b/src/interface/api-inbound.yaml
@@ -323,6 +323,147 @@ paths:
       operationId: ThirdpartyRequestsTransactionsPost
       summary: example get
       description: The HTTP request GET /hello is used to return some example json.
+  '/thirdpartyRequests/transactions/{ID}/authorizations':
+    put:
+      operationId: UpdateThirdpartyAuthorization
+      summary: UpdateThirdpartyAuthorization
+      description: |
+        The HTTP request `PUT /thirdpartyRequests/transactions/{id}/authorizations` is used by the auth-service to update a thirdparty authorization after successful validation.
+        For an unsuccessful authorization result, the `PUT /thirdpartyRequests/transactions/{id}/authorizations/error` will be called by the auth-service, instead of this endpoint.
+      parameters:
+        - name: ID
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The identifier value.
+        - name: Content-Length
+          in: header
+          required: false
+          schema:
+            type: integer
+          description: |
+            The `Content-Length` header field indicates the anticipated size of the
+            payload body. Only sent if there is a body.
+            **Note:** The API supports a maximum size of 5242880 bytes (5 Megabytes).
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          required: true
+          description: |
+            The `Content-Type` header indicates the specific version of the API used
+            to send the payload body.
+        - name: Date
+          in: header
+          schema:
+            type: string
+          required: true
+          description: The `Date` header field indicates the date when the request was sent.
+        - name: X-Forwarded-For
+          in: header
+          schema:
+            type: string
+          required: false
+          description: |
+            The `X-Forwarded-For` header field is an unofficially accepted standard used
+            for informational purposes of the originating client IP address, as a
+            request might pass multiple proxies, firewalls, and so on. Multiple
+            `X-Forwarded-For` values should be expected and supported by implementers
+            of the API.
+            **Note:** An alternative to `X-Forwarded-For` is defined in
+            [RFC 7239](https://tools.ietf.org/html/rfc7239).
+            However, to this point RFC 7239 is less-used and supported than `X-Forwarded-For`.
+        - name: FSPIOP-Source
+          in: header
+          schema:
+            type: string
+          required: true
+          description: |
+            The `FSPIOP-Source` header field is a non-HTTP standard field
+            used by the API for identifying the sender of the HTTP request.
+            The field should be set by the original sender of the request.
+            Required for routing and signature verification
+            (see header field `FSPIOP-Signature`).
+        - name: FSPIOP-Destination
+          in: header
+          schema:
+            type: string
+          required: false
+          description: |
+            The `FSPIOP-Destination` header field is a non-HTTP standard field used by
+            the API for HTTP header based routing of requests and responses to the
+            destination. The field should be set by the original sender of the request
+            (if known), so that any entities between the client and the server do not
+            need to parse the payload for routing purposes.
+        - name: FSPIOP-Encryption
+          in: header
+          schema:
+            type: string
+          required: false
+          description: |
+            The `FSPIOP-Encryption` header field is a non-HTTP standard field used by
+            the API for applying end-to-end encryption of the request.
+        - name: FSPIOP-Signature
+          in: header
+          schema:
+            type: string
+          required: false
+          description: |
+            The `FSPIOP-Signature` header field is a non-HTTP standard field used by the
+            API for applying an end-to-end request signature.
+        - name: FSPIOP-URI
+          in: header
+          schema:
+            type: string
+          required: false
+          description: |
+            The `FSPIOP-URI` header field is a non-HTTP standard field used by the API
+            for signature verification, should contain the service URI. Required if
+            signature verification is used, for more information, see
+            [the API Signature document](https://github.com/mojaloop/docs/tree/master/Specification%20Document%20Set).
+        - name: FSPIOP-HTTP-Method
+          in: header
+          schema:
+            type: string
+          required: false
+          description: |
+            The `FSPIOP-HTTP-Method` header field is a non-HTTP standard field used by
+            the API for signature verification, should contain the service HTTP method.
+            Required if signature verification is used, for more information, see
+            [the API Signature document](https://github.com/mojaloop/docs/tree/master/Specification%20Document%20Set).
+      requestBody:
+        description: The thirdparty authorization details to update
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateThirdpartyAuthorizationRequest'
+            example:
+              challenge: <QuoteResponse object>
+              value: <base64 encoded binary - the signed quote response object>
+              consentId: 8d34f91d-d078-4077-8263-2c0498dhbjr
+              sourceAccountId: dfspa.alice.1234
+              status: VERIFIED
+      responses:
+        '200':
+          $ref: '#/paths/~1hello/get/responses/200'
+        '400':
+          $ref: '#/paths/~1hello/get/responses/400'
+        '401':
+          $ref: '#/paths/~1hello/get/responses/401'
+        '403':
+          $ref: '#/paths/~1hello/get/responses/403'
+        '404':
+          $ref: '#/paths/~1hello/get/responses/404'
+        '405':
+          $ref: '#/paths/~1hello/get/responses/405'
+        '406':
+          $ref: '#/paths/~1hello/get/responses/406'
+        '501':
+          $ref: '#/paths/~1hello/get/responses/501'
+        '503':
+          $ref: '#/paths/~1hello/get/responses/503'
 components:
   responses:
     InboundAuthorizationsIDPutResponse:
@@ -897,3 +1038,42 @@ components:
         - amount
         - transactionType
         - expiration
+    UpdateThirdpartyAuthorizationRequest:
+      title: UpdateThirdpartyAuthorizationRequest
+      type: object
+      description: 'The object sent in the PUT /thirdpartyRequests/transactions/{id}/authorizations request.'
+      properties:
+        challenge:
+          type: string
+          description: The original Challenge Object as a JSON string
+        value:
+          allOf:
+            - type: string
+              pattern: '^[A-Za-z0-9-_]+[=]{0,2}$'
+              description: |
+                The API data type BinaryString is a JSON String.
+                The string is a base64url  encoding of a string of raw bytes,
+                where padding (character ‘=’) is added at the end of the data if
+                needed to ensure that the string is a multiple of 4 characters.
+                The length restriction indicates the allowed number of characters.
+          description: Base64 encoded binary string - the signed challenge
+        consentId:
+          allOf:
+            - $ref: '#/components/schemas/ThirdpartyTransactionRequest/properties/consentId/allOf/0'
+          description: |
+            Common ID between the PISP and FSP for the Consent object This tells DFSP and auth-service which constent allows the PISP to initiate transaction.
+        sourceAccountId:
+          allOf:
+            - $ref: '#/components/schemas/AccountId'
+          description: 'DFSP specific account identifiers, e.g. `dfspa.alice.1234`'
+        status:
+          type: string
+          enum:
+            - VERIFIED
+          description: The status of the authorization. This value must be `VERIFIED` for a PUT request
+      required:
+        - challenge
+        - value
+        - consentId
+        - sourceAccountId
+        - status

--- a/src/interface/api-outbound-template.yaml
+++ b/src/interface/api-outbound-template.yaml
@@ -124,6 +124,47 @@ paths:
       operationId: HelloGet
       summary: example get
       description: The HTTP request GET /hello is used to return some example json.
+  /thirdpartyRequests/transactions/{ID}/authorizations:
+    post:
+      operationId: VerifyThirdPartyAuthorization
+      summary: VerifyThirdPartyAuthorization
+      description: |
+        The HTTP request `POST /thirdpartyRequests/transactions/{id}/authorizations` is used by the DFSP to verify a third party authorization.
+      parameters:
+        #Path
+        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/ID.yaml'
+      requestBody:
+        description: The thirdparty authorization details to verify
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyThirdPartyAuthorizationRequest'
+            example:
+              challenge: '<QuoteResponse object>'
+              value: '<base64 encoded binary - the signed quote response object>'
+              consentId: '8d34f91d-d078-4077-8263-2c0498dhbjr'
+              sourceAccountId: 'dfspa.alice.1234'
+              status: 'PENDING'
+      responses:
+        '200':
+          $ref: '#/components/responses/ThirdPartyAuthorizationResponse'
+        '400':
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/400'
+        '401':
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/401'
+        '403':
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/403'
+        '404':
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/404'
+        '405':
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/405'
+        '406':
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/406'
+        '501':
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/501'
+        '503':
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/503'
 components:
   schemas:
     AuthorizationsState:
@@ -185,6 +226,91 @@ components:
         - transactionRequestId
         - quote
       additionalProperties: false
+    AccountId:
+      type: string
+      description: >
+        A long-lived account identifier provided by the DFSP
+        this MUST NOT be Bank Account Number or anything that
+        may expose a User's private bank account information
+    ThirdPartyAuthorizationsState:
+      title: ThirdPartyAuthorizationsState
+      description: Transition state of thirdparty authorizations
+      type: string
+      enum:
+        - WAITING_FOR_AUTHORIZATION_REQUEST
+        - COMPLETED
+        - ERROR_OCCURRED
+    VerifyThirdPartyAuthorizationRequest:
+      title: VerifyThirdPartyAuthorizationRequest
+      type: object
+      description: The object sent in the POST /thirdpartyRequests/transactions/{id}/authorizations request.
+      properties:
+        toParticipantId:
+          type: string
+          description: The id of the destination participant, in this case, a DFSP
+        challenge:
+          type: string
+          description: The original Challenge Object as a JSON string
+        value:
+          allOf:
+            - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/schemas/BinaryString.yaml'
+          description: 'Base64 encoded binary string - the signed challenge'
+        consentId:
+          allOf:
+            - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/schemas/CorrelationId.yaml'
+          description: >
+            Common ID between the PISP and FSP for the Consent object
+            This tells DFSP and auth-service which constent allows the PISP to initiate transaction.
+        sourceAccountId:
+          allOf:
+            - $ref: '#/components/schemas/AccountId'
+          description: DFSP specific account identifiers, e.g. `dfspa.alice.1234`
+        status:
+          type: string
+          enum:
+            - PENDING
+          description: The status of the authorization. This MUST be PENDING for a POST request
+      required:
+        - challenge
+        - value
+        - consentId
+        - sourceAccountId
+        - status
+    ThirdPartyAuthorizationResponse:
+      title: ThirdPartyAuthorizationResponse
+      type: object
+      description: The response for POST /thirdpartyRequests/transactions/{id}/authorizations request.
+      properties:
+        challenge:
+          type: string
+          description: The original Challenge Object as a JSON string
+        value:
+          allOf:
+            - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/schemas/BinaryString.yaml'
+          description: 'Base64 encoded binary string - the signed challenge'
+        consentId:
+          allOf:
+            - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/schemas/CorrelationId.yaml'
+          description: >
+            Common ID between the PISP and FSP for the Consent object
+            This tells DFSP and auth-service which constent allows the PISP to initiate transaction.
+        sourceAccountId:
+          allOf:
+            - $ref: '#/components/schemas/AccountId'
+          description: DFSP specific account identifiers, e.g. `dfspa.alice.1234`
+        status:
+          type: string
+          enum:
+            - VERIFIED
+          description: The status of the authorization.
+        currentState:
+          $ref: '#/components/schemas/ThirdPartyAuthorizationsState'
+      required:
+        - challenge
+        - value
+        - consentId
+        - sourceAccountId
+        - status
 
   responses:
     OutboundAuthorizationsPostResponse:
@@ -206,3 +332,9 @@ components:
                   $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/schemas/AuthorizationResponse.yaml'
                 currentState:
                   $ref: '#/components/schemas/AuthorizationsState'
+    ThirdPartyAuthorizationResponse:
+      description: 'ThirdPartyAuthorizationResponse'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ThirdPartyAuthorizationResponse'

--- a/src/interface/api-outbound.yaml
+++ b/src/interface/api-outbound.yaml
@@ -232,6 +232,51 @@ paths:
       operationId: HelloGet
       summary: example get
       description: The HTTP request GET /hello is used to return some example json.
+  '/thirdpartyRequests/transactions/{ID}/authorizations':
+    post:
+      operationId: VerifyThirdPartyAuthorization
+      summary: VerifyThirdPartyAuthorization
+      description: |
+        The HTTP request `POST /thirdpartyRequests/transactions/{id}/authorizations` is used by the DFSP to verify a third party authorization.
+      parameters:
+        - name: ID
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The identifier value.
+      requestBody:
+        description: The thirdparty authorization details to verify
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyThirdPartyAuthorizationRequest'
+            example:
+              challenge: <QuoteResponse object>
+              value: <base64 encoded binary - the signed quote response object>
+              consentId: 8d34f91d-d078-4077-8263-2c0498dhbjr
+              sourceAccountId: dfspa.alice.1234
+              status: PENDING
+      responses:
+        '200':
+          $ref: '#/components/responses/ThirdPartyAuthorizationResponse'
+        '400':
+          $ref: '#/paths/~1hello/get/responses/400'
+        '401':
+          $ref: '#/paths/~1hello/get/responses/401'
+        '403':
+          $ref: '#/paths/~1hello/get/responses/403'
+        '404':
+          $ref: '#/paths/~1hello/get/responses/404'
+        '405':
+          $ref: '#/paths/~1hello/get/responses/405'
+        '406':
+          $ref: '#/paths/~1hello/get/responses/406'
+        '501':
+          $ref: '#/paths/~1hello/get/responses/501'
+        '503':
+          $ref: '#/paths/~1hello/get/responses/503'
 components:
   schemas:
     AuthorizationsState:
@@ -604,6 +649,94 @@ components:
         - transactionRequestId
         - quote
       additionalProperties: false
+    AccountId:
+      type: string
+      description: |
+        A long-lived account identifier provided by the DFSP this MUST NOT be Bank Account Number or anything that may expose a User's private bank account information
+    ThirdPartyAuthorizationsState:
+      title: ThirdPartyAuthorizationsState
+      description: Transition state of thirdparty authorizations
+      type: string
+      enum:
+        - WAITING_FOR_AUTHORIZATION_REQUEST
+        - COMPLETED
+        - ERROR_OCCURRED
+    VerifyThirdPartyAuthorizationRequest:
+      title: VerifyThirdPartyAuthorizationRequest
+      type: object
+      description: 'The object sent in the POST /thirdpartyRequests/transactions/{id}/authorizations request.'
+      properties:
+        toParticipantId:
+          type: string
+          description: 'The id of the destination participant, in this case, a DFSP'
+        challenge:
+          type: string
+          description: The original Challenge Object as a JSON string
+        value:
+          allOf:
+            - $ref: '#/components/schemas/ThirdPartyAuthorizationResponse/properties/value/allOf/0'
+          description: Base64 encoded binary string - the signed challenge
+        consentId:
+          allOf:
+            - $ref: '#/components/schemas/OutboundAuthorizationsPostRequest/properties/transactionId'
+          description: |
+            Common ID between the PISP and FSP for the Consent object This tells DFSP and auth-service which constent allows the PISP to initiate transaction.
+        sourceAccountId:
+          allOf:
+            - $ref: '#/components/schemas/AccountId'
+          description: 'DFSP specific account identifiers, e.g. `dfspa.alice.1234`'
+        status:
+          type: string
+          enum:
+            - PENDING
+          description: The status of the authorization. This MUST be PENDING for a POST request
+      required:
+        - challenge
+        - value
+        - consentId
+        - sourceAccountId
+        - status
+    ThirdPartyAuthorizationResponse:
+      title: ThirdPartyAuthorizationResponse
+      type: object
+      description: 'The response for POST /thirdpartyRequests/transactions/{id}/authorizations request.'
+      properties:
+        challenge:
+          type: string
+          description: The original Challenge Object as a JSON string
+        value:
+          allOf:
+            - type: string
+              pattern: '^[A-Za-z0-9-_]+[=]{0,2}$'
+              description: |
+                The API data type BinaryString is a JSON String.
+                The string is a base64url  encoding of a string of raw bytes,
+                where padding (character ‘=’) is added at the end of the data if
+                needed to ensure that the string is a multiple of 4 characters.
+                The length restriction indicates the allowed number of characters.
+          description: Base64 encoded binary string - the signed challenge
+        consentId:
+          allOf:
+            - $ref: '#/components/schemas/OutboundAuthorizationsPostRequest/properties/transactionId'
+          description: |
+            Common ID between the PISP and FSP for the Consent object This tells DFSP and auth-service which constent allows the PISP to initiate transaction.
+        sourceAccountId:
+          allOf:
+            - $ref: '#/components/schemas/AccountId'
+          description: 'DFSP specific account identifiers, e.g. `dfspa.alice.1234`'
+        status:
+          type: string
+          enum:
+            - VERIFIED
+          description: The status of the authorization.
+        currentState:
+          $ref: '#/components/schemas/ThirdPartyAuthorizationsState'
+      required:
+        - challenge
+        - value
+        - consentId
+        - sourceAccountId
+        - status
   responses:
     OutboundAuthorizationsPostResponse:
       description: |
@@ -672,3 +805,9 @@ components:
                 example: ENTERED
               currentState:
                 $ref: '#/components/schemas/AuthorizationsState'
+    ThirdPartyAuthorizationResponse:
+      description: ThirdPartyAuthorizationResponse
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ThirdPartyAuthorizationResponse'

--- a/src/models/outbound/thirdparty.authorizations.model.ts
+++ b/src/models/outbound/thirdparty.authorizations.model.ts
@@ -1,0 +1,210 @@
+/*****
+ License
+ --------------
+ Copyright © 2020 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the "License")
+ and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed
+ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ - Sridhar Voruganti <sridhar.voruganti@modusbox.com>
+ --------------
+ ******/
+import {
+  InboundThirdpartyAuthorizationsPutRequest,
+  OutboundThirdpartyAuthorizationsPostResponse,
+  OutboundThirdpartyAuthorizationsModelConfig,
+  OutboundThirdpartyAuthorizationsModelState,
+  OutboundThirdpartyAuthorizationsData,
+  OutboundThirdpartyAuthorizationStateMachine
+} from '~/models/thirdparty.authorizations.interface'
+
+import { PersistentModel } from '~/models/persistent.model'
+import { StateMachineConfig } from 'javascript-state-machine'
+import { Message, PubSub } from '~/shared/pub-sub'
+import { ThirdpartyRequests } from '@mojaloop/sdk-standard-components'
+import inspect from '~/shared/inspect'
+
+export class OutboundThirdpartyAuthorizationsModel
+  extends PersistentModel<OutboundThirdpartyAuthorizationStateMachine, OutboundThirdpartyAuthorizationsData> {
+  protected config: OutboundThirdpartyAuthorizationsModelConfig
+
+  constructor(
+    data: OutboundThirdpartyAuthorizationsData,
+    config: OutboundThirdpartyAuthorizationsModelConfig
+  ) {
+    const spec: StateMachineConfig = {
+      init: 'start',
+      transitions: [
+        { name: 'thirdpartyRequestAuthorization', from: 'start', to: 'succeeded' }
+      ],
+      methods: {
+        // specific transitions handlers methods
+        onThirdpartyRequestAuthorization: () => this.onThirdpartyRequestAuthorization()
+      }
+    }
+    super(data, config, spec)
+    this.config = { ...config }
+  }
+
+  // getters
+  get pubSub(): PubSub {
+    return this.config.pubSub
+  }
+
+  get requests(): ThirdpartyRequests {
+    return this.config.requests
+  }
+
+  static notificationChannel(id: string): string {
+    if (!(id && id.toString().length > 0)) {
+      throw new Error('OutboundThirdpartyAuthorizationsModel.notificationChannel: \'id\' parameter is required')
+    }
+    // channel name
+    return `3p_req_trxn_authz_${id}`
+  }
+
+  /**
+   * Requests Thirdparty Authorization
+   * Starts the thirdparty authorization process by sending a 
+   * POST /thirdpartyRequests/transactions/${transactionRequestId}/authorizations request to switch
+   * than await for a notification on PUT /thirdpartyRequests/transactions/${transactionRequestId}/authorizations
+   * from the PubSub that the Authorization has been resolved
+   */
+  async onThirdpartyRequestAuthorization(): Promise<void> {
+    const channel = OutboundThirdpartyAuthorizationsModel.notificationChannel(this.config.key)
+    const pubSub: PubSub = this.pubSub
+
+    // eslint-disable-next-line no-async-promise-executor
+    return new Promise(async (resolve, reject) => {
+      let subId = 0
+      try {
+        // in handlers/inbound is implemented putThirdpartyAuthorizationsById handler
+        // which publish thirdparty authorizations response to channel
+        subId = this.pubSub.subscribe(channel, async (channel: string, message: Message, sid: number) => {
+          // first unsubscribe
+          pubSub.unsubscribe(channel, sid)
+
+          const putResponse = { ...message as unknown as InboundThirdpartyAuthorizationsPutRequest }
+          // store response which will be returned by 'getResponse' method in workflow 'run'
+          this.data.response = {
+            ...putResponse,
+            currentState: OutboundThirdpartyAuthorizationsModelState[
+              this.data.currentState as keyof typeof OutboundThirdpartyAuthorizationsModelState
+            ]
+          }
+          resolve()
+        })
+
+        // POST /thirdpartyRequests/transactions/${transactionRequestId}/authorizations request to the switch
+        const res = await this.requests.postThirdpartyRequestsTransactionsAuthorizations(this.data.request, this.config.key, this.data.toParticipantId)
+        this.logger.push({ res })
+        this.logger.info('ThirdpartyAuthorizations request sent to peer')
+      } catch (error) {
+        this.logger.push(error)
+        this.logger.error('ThirdpartyAuthorizations request error')
+        pubSub.unsubscribe(channel, subId)
+        reject(error)
+      }
+    })
+  }
+
+  /**
+   * Returns an object representing the final state of the thirdparty authorization suitable for the outbound API
+   *
+   * @returns {object} - Response representing the result of the thirdparty authorization process
+   */
+  getResponse(): OutboundThirdpartyAuthorizationsPostResponse | void {
+    return this.data.response
+  }
+
+  /**
+   * runs the workflow
+   */
+  async run(): Promise<OutboundThirdpartyAuthorizationsPostResponse | void> {
+    const data = this.data
+    try {
+      // run transitions based on incoming state
+      switch (data.currentState) {
+        case 'start':
+          // the first transition is thirdpartyRequestAuthorization
+          await this.fsm.thirdpartyRequestAuthorization()
+          this.logger.info(
+            `ThirdpartyAuthorizations requested for ${data.transactionRequestId},  currentState: ${data.currentState}`
+          )
+        /* falls through */
+
+        case 'succeeded':
+          // all steps complete so return
+          this.logger.info('ThirdpartyAuthorizations completed successfully')
+          return this.getResponse()
+
+        case 'errored':
+          // stopped in errored state
+          this.logger.info('State machine in errored state')
+          return
+      }
+    } catch (err) {
+      this.logger.info(`Error running ThirdpartyAuthorizations model: ${inspect(err)}`)
+
+      // as this function is recursive, we don't want to error the state machine multiple times
+      if (data.currentState !== 'errored') {
+        // err should not have a thirdpartythirdpartyAuthorizationState property here!
+        if (err.thirdpartyAuthorizationState) {
+          this.logger.info('State machine is broken')
+        }
+        // transition to errored state
+        await this.fsm.error(err)
+
+        // avoid circular ref between thirdpartyAuthorizationState.lastError and err
+        err.thirdpartyAuthorizationState = { ...this.getResponse() }
+      }
+      throw err
+    }
+  }
+}
+
+export async function create(
+  data: OutboundThirdpartyAuthorizationsData,
+  config: OutboundThirdpartyAuthorizationsModelConfig
+): Promise<OutboundThirdpartyAuthorizationsModel> {
+  // create a new model
+  const model = new OutboundThirdpartyAuthorizationsModel(data, config)
+
+  // enforce to finish any transition to state specified by data.currentState or spec.init
+  await model.fsm.state
+  return model
+}
+
+// loads PersistentModel from KVS storage using given `config` and `spec`
+export async function loadFromKVS(
+  config: OutboundThirdpartyAuthorizationsModelConfig
+): Promise<OutboundThirdpartyAuthorizationsModel> {
+  try {
+    const data = await config.kvs.get<OutboundThirdpartyAuthorizationsData>(config.key)
+    if (!data) {
+      throw new Error(`No data found in KVS for: ${config.key}`)
+    }
+    config.logger.push({ data })
+    config.logger.info('data loaded from KVS')
+    return new OutboundThirdpartyAuthorizationsModel(data, config)
+  } catch (err) {
+    config.logger.push({ err })
+    config.logger.info(`Error loading data from KVS for key: ${config.key}`)
+    throw err
+  }
+}

--- a/src/models/thirdparty.authorizations.interface.ts
+++ b/src/models/thirdparty.authorizations.interface.ts
@@ -1,0 +1,74 @@
+/*****
+ License
+ --------------
+ Copyright © 2020 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the "License")
+ and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed
+ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ - Sridhar Voruganti <sridhar.voruganti@modusbox.com>
+ --------------
+ ******/
+import {
+  ControlledStateMachine,
+  PersistentModelConfig, StateData
+} from '~/models/persistent.model'
+import { Method } from 'javascript-state-machine'
+import {
+  PostThirdpartyRequestsTransactionsAuthorizationsRequest,
+  ThirdpartyRequests
+} from '@mojaloop/sdk-standard-components'
+import { PubSub } from '~/shared/pub-sub'
+
+export enum OutboundThirdpartyAuthorizationsModelState {
+  start = 'WAITING_FOR_AUTHORIZATION_REQUEST',
+  succeeded = 'COMPLETED',
+  errored = 'ERROR_OCCURRED'
+}
+
+export interface InboundThirdpartyAuthorizationsPutRequest {
+  challenge: string;
+  consentId: string;
+  sourceAccountId: string;
+  status: 'PENDING' | 'VERIFIED';
+  value: string;
+}
+
+export interface OutboundThirdpartyAuthorizationsPostRequest extends InboundThirdpartyAuthorizationsPutRequest {
+  toParticipantId: string;
+}
+
+export interface OutboundThirdpartyAuthorizationsPostResponse extends InboundThirdpartyAuthorizationsPutRequest {
+  currentState: OutboundThirdpartyAuthorizationsModelState;
+}
+
+export interface OutboundThirdpartyAuthorizationStateMachine extends ControlledStateMachine {
+  thirdpartyRequestAuthorization: Method
+  onThirdpartyRequestAuthorization: Method
+}
+
+export interface OutboundThirdpartyAuthorizationsModelConfig extends PersistentModelConfig {
+  pubSub: PubSub
+  requests: ThirdpartyRequests
+}
+
+export interface OutboundThirdpartyAuthorizationsData extends StateData {
+  toParticipantId: string
+  request: PostThirdpartyRequestsTransactionsAuthorizationsRequest
+  response?: OutboundThirdpartyAuthorizationsPostResponse
+}

--- a/test/features/thirdparty-authorizations-inbound.feature
+++ b/test/features/thirdparty-authorizations-inbound.feature
@@ -1,0 +1,6 @@
+Feature: Inbound API server
+
+Scenario: UpdateThirdpartyAuthorization
+  Given Inbound API server
+  When I send a 'UpdateThirdpartyAuthorization' request
+  Then I get a response with a status code of '200'

--- a/test/features/thirdparty-authorizations-outbound.feature
+++ b/test/features/thirdparty-authorizations-outbound.feature
@@ -1,0 +1,6 @@
+Feature: Outbound API server
+
+Scenario: VerifyThirdPartyAuthorization
+  Given Outbound API server
+  When I send a 'VerifyThirdPartyAuthorization' request
+  Then I get a response with a status code of '200'

--- a/test/step-definitions/thirdparty-authorizations-inbound.step.ts
+++ b/test/step-definitions/thirdparty-authorizations-inbound.step.ts
@@ -1,0 +1,96 @@
+/*****
+ License
+ --------------
+ Copyright © 2020 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the "License")
+ and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed
+ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+
+  - Sridhar Voruganti <sridhar.voruganti@modusbox.com>
+
+ --------------
+ ******/
+
+import { Server, ServerInjectResponse } from '@hapi/hapi'
+import { ServerAPI, ServerConfig } from '~/server'
+import { defineFeature, loadFeature } from 'jest-cucumber'
+import Config from '~/shared/config'
+import Handlers from '~/handlers'
+import index from '~/index'
+import path from 'path'
+
+const apiPath = path.resolve(__dirname, '../../src/interface/api-inbound.yaml')
+const featurePath = path.resolve(__dirname, '../features/thirdparty-authorizations-inbound.feature')
+const feature = loadFeature(featurePath)
+
+async function prepareInboundAPIServer(): Promise<Server> {
+  const serverConfig: ServerConfig = {
+    port: Config.INBOUND.PORT,
+    host: Config.INBOUND.HOST,
+    api: ServerAPI.inbound
+  }
+  const serverHandlers = {
+    ...Handlers.Shared,
+    ...Handlers.Inbound
+  }
+  return index.server.setupAndStart(serverConfig, apiPath, serverHandlers)
+}
+
+defineFeature(feature, (test): void => {
+  let server: Server
+  let response: ServerInjectResponse
+
+  afterEach((done): void => {
+    jest.resetAllMocks()
+    jest.resetModules()
+    server.events.on('stop', done)
+    server.stop()
+  })
+
+  test('UpdateThirdpartyAuthorization', ({ given, when, then }): void => {
+    given('Inbound API server', async (): Promise<void> => {
+      server = await prepareInboundAPIServer()
+    })
+
+    when('I send a \'UpdateThirdpartyAuthorization\' request', async (): Promise<ServerInjectResponse> => {
+      jest.mock('~/shared/kvs')
+      jest.mock('~/shared/pub-sub')
+      const request = {
+        method: 'PUT',
+        url: '/thirdpartyRequests/transactions/123/authorizations',
+        headers: {
+          'Content-Type': 'application/json',
+          'FSPIOP-Source': 'switch',
+          'Date': 'Thu, 24 Jan 2019 10:22:12 GMT',
+          'FSPIOP-Destination': 'dfspA'
+        },
+        payload: {
+          challenge: 'challenge',
+          consentId: '8e34f91d-d078-4077-8263-2c047876fcf6',
+          sourceAccountId: 'dfspa.alice.1234',
+          status: 'VERIFIED',
+          value: 'value'
+        }
+      }
+      response = await server.inject(request)
+      return response
+    })
+
+    then('I get a response with a status code of \'200\'', (): void => {
+      expect(response.statusCode).toBe(200)
+    })
+  })
+})

--- a/test/step-definitions/thirdparty-authorizations-outbound.step.ts
+++ b/test/step-definitions/thirdparty-authorizations-outbound.step.ts
@@ -1,0 +1,137 @@
+/*****
+ License
+ --------------
+ Copyright © 2020 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the "License")
+ and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed
+ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+
+ - Sridhar Voruganti <sridhar.voruganti@modusbox.com>
+
+ --------------
+ ******/
+
+import { Handlers, ServerAPI, ServerConfig } from '~/server'
+import { Server, ServerInjectResponse } from '@hapi/hapi'
+import { defineFeature, loadFeature } from 'jest-cucumber'
+import { NotificationCallback, Message, PubSub } from '~/shared/pub-sub'
+import { RedisConnectionConfig } from '~/shared/redis-connection'
+import {
+    OutboundThirdpartyAuthorizationsModelState,
+    InboundThirdpartyAuthorizationsPutRequest
+} from '~/models/thirdparty.authorizations.interface'
+import Config from '~/shared/config'
+import index from '~/index'
+import path from 'path'
+
+const apiPath = path.resolve(__dirname, '../../src/interface/api-outbound.yaml')
+const featurePath = path.resolve(__dirname, '../features/thirdparty-authorizations-outbound.feature')
+const feature = loadFeature(featurePath)
+
+jest.mock('~/shared/pub-sub', () => {
+    let handler: NotificationCallback
+    let subId = 0
+    return {
+        PubSub: jest.fn(() => ({
+            isConnected: true,
+            subscribe: jest.fn(
+                (_channel: string, cb: NotificationCallback) => {
+                    handler = cb
+                    return ++subId
+                }
+            ),
+            unsubscribe: jest.fn(),
+            publish: jest.fn(
+                async (channel: string, message: Message) => {
+                    return handler(channel, message, subId)
+                }
+            ),
+            connect: jest.fn(() => Promise.resolve()),
+            disconnect: jest.fn()
+        }))
+    }
+})
+
+async function prepareOutboundAPIServer (): Promise<Server> {
+    const serverConfig: ServerConfig = {
+        port: Config.OUTBOUND.PORT,
+        host: Config.OUTBOUND.HOST,
+        api: ServerAPI.outbound
+    }
+    const serverHandlers = {
+        ...Handlers.Shared,
+        ...Handlers.Outbound
+    }
+    return index.server.setupAndStart(serverConfig, apiPath, serverHandlers)
+}
+
+defineFeature(feature, (test): void => {
+    let server: Server
+    let response: ServerInjectResponse
+
+    afterEach((done): void => {
+        server.events.on('stop', done)
+        server.stop()
+    })
+
+    test('VerifyThirdPartyAuthorization', ({ given, when, then }): void => {
+        const putThirdpartyAuthResponse: InboundThirdpartyAuthorizationsPutRequest = {
+            challenge: 'challenge',
+            consentId: '8e34f91d-d078-4077-8263-2c047876fcf6',
+            sourceAccountId: 'dfspa.alice.1234',
+            status: 'VERIFIED',
+            value: 'value'
+        }
+
+        given('Outbound API server', async (): Promise<void> => {
+            server = await prepareOutboundAPIServer()
+        })
+
+        when('I send a \'VerifyThirdPartyAuthorization\' request', async (): Promise<ServerInjectResponse> => {
+            const request = {
+                method: 'POST',
+                url: '/thirdpartyRequests/transactions/12345/authorizations',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                payload: {
+                    toParticipantId: 'dfspA',
+                    challenge: 'challenge',
+                    consentId: '8e34f91d-d078-4077-8263-2c047876fcf6',
+                    sourceAccountId: 'dfspa.alice.1234',
+                    status: 'PENDING',
+                    value: 'value',
+                }
+            }
+            const pubSub = new PubSub({} as RedisConnectionConfig)
+            // defer publication to notification channel
+            setTimeout(() => pubSub.publish(
+                'some-channel',
+                putThirdpartyAuthResponse as unknown as Message
+            ), 10)
+            response = await server.inject(request)
+            return response
+        })
+
+        then('I get a response with a status code of \'200\'', (): void => {
+            expect(response.statusCode).toBe(200)
+            expect(response.result).toEqual({
+                ...putThirdpartyAuthResponse,
+                currentState: OutboundThirdpartyAuthorizationsModelState.succeeded
+            })
+        })
+    })
+})

--- a/test/unit/models/outbound/thirdparty.authorizations.model.test.ts
+++ b/test/unit/models/outbound/thirdparty.authorizations.model.test.ts
@@ -1,0 +1,336 @@
+/*****
+ License
+ --------------
+ Copyright © 2020 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the "License")
+ and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed
+ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ - Sridhar Voruganti <sridhar.voruganti@modusbox.com>
+ --------------
+ ******/
+import { KVS } from '~/shared/kvs'
+import { Message, NotificationCallback, PubSub } from '~/shared/pub-sub'
+
+import {
+  OutboundThirdpartyAuthorizationsModelConfig,
+  OutboundThirdpartyAuthorizationsModelState,
+  OutboundThirdpartyAuthorizationsData,
+  InboundThirdpartyAuthorizationsPutRequest
+} from '~/models/thirdparty.authorizations.interface'
+
+import {
+  OutboundThirdpartyAuthorizationsModel,
+  create,
+  loadFromKVS
+} from '~/models/outbound/thirdparty.authorizations.model'
+
+import {
+  PostThirdpartyRequestsTransactionsAuthorizationsRequest,
+  ThirdpartyRequests
+} from '@mojaloop/sdk-standard-components'
+import { RedisConnectionConfig } from '~/shared/redis-connection'
+import { mocked } from 'ts-jest/utils'
+
+import mockLogger from 'test/unit/mockLogger'
+import shouldNotBeExecuted from 'test/unit/shouldNotBeExecuted'
+import sortedArray from 'test/unit/sortedArray'
+
+// mock KVS default exported class
+jest.mock('~/shared/kvs')
+
+// mock PubSub default exported class
+jest.mock('~/shared/pub-sub')
+
+describe('OutboundThirdpartyAuthorizationsModel', () => {
+  const ConnectionConfig: RedisConnectionConfig = {
+    port: 6789,
+    host: 'localhost',
+    logger: mockLogger()
+  }
+  let modelConfig: OutboundThirdpartyAuthorizationsModelConfig
+
+  beforeEach(async () => {
+    modelConfig = {
+      kvs: new KVS(ConnectionConfig),
+      key: 'cache-key',
+      logger: ConnectionConfig.logger,
+      pubSub: new PubSub(ConnectionConfig),
+      requests: {
+        postThirdpartyRequestsTransactionsAuthorizations: jest.fn()
+      } as unknown as ThirdpartyRequests
+    }
+    await modelConfig.kvs.connect()
+    await modelConfig.pubSub.connect()
+  })
+
+  afterEach(async () => {
+    await modelConfig.kvs.disconnect()
+    await modelConfig.pubSub.disconnect()
+  })
+
+  function checkThirdpartyAuthorizationsModelLayout(am: OutboundThirdpartyAuthorizationsModel, optData?: OutboundThirdpartyAuthorizationsData) {
+    expect(am).toBeTruthy()
+    expect(am.data).toBeDefined()
+    expect(am.fsm.state).toEqual(optData?.currentState || 'start')
+
+    // check new getters
+    expect(am.pubSub).toEqual(modelConfig.pubSub)
+    expect(am.requests).toEqual(modelConfig.requests)
+
+    // check is fsm correctly constructed
+    expect(typeof am.fsm.init).toEqual('function')
+    expect(typeof am.fsm.thirdpartyRequestAuthorization).toEqual('function')
+
+    // check fsm notification handler
+    expect(typeof am.onThirdpartyRequestAuthorization).toEqual('function')
+
+    expect(sortedArray(am.fsm.allStates())).toEqual(['errored', 'none', 'start', 'succeeded'])
+    expect(sortedArray(am.fsm.allTransitions())).toEqual(['error', 'init', 'thirdpartyRequestAuthorization'])
+  }
+
+  it('module layout', () => {
+    expect(typeof OutboundThirdpartyAuthorizationsModel).toEqual('function')
+    expect(typeof loadFromKVS).toEqual('function')
+    expect(typeof create).toEqual('function')
+  })
+
+  describe('notificationChannel', () => {
+    it('should generate proper channel name', () => {
+      expect(OutboundThirdpartyAuthorizationsModel.notificationChannel(modelConfig.key)).toEqual('3p_req_trxn_authz_' + modelConfig.key)
+    })
+
+    it('input validation', () => {
+      expect(
+        () => OutboundThirdpartyAuthorizationsModel.notificationChannel(null as unknown as string)
+      ).toThrow()
+    })
+  })
+
+  describe('request thirdparty authorization flow', () => {
+    let subId = 0
+    let channel: string
+    let handler: NotificationCallback
+    let data: OutboundThirdpartyAuthorizationsData
+    let putResponse: InboundThirdpartyAuthorizationsPutRequest
+    beforeEach(() => {
+      mocked(modelConfig.pubSub.subscribe).mockImplementationOnce(
+        (_channel: string, cb: NotificationCallback) => {
+          handler = cb
+          return ++subId
+        }
+      )
+
+      mocked(modelConfig.pubSub.publish).mockImplementationOnce(
+        async (channel: string, message: Message) => handler(channel, message, subId)
+      )
+
+      data = {
+        toParticipantId: 'dfspA',
+        request: {
+          challenge: 'challenge',
+          consentId: 'consentId',
+          sourceAccountId: 'sourceAccountId',
+          status: 'PENDING',
+          value: 'value'
+        } as unknown as PostThirdpartyRequestsTransactionsAuthorizationsRequest, // minimal request body
+        currentState: 'start'
+      }
+
+      channel = OutboundThirdpartyAuthorizationsModel.notificationChannel(modelConfig.key)
+
+      putResponse = {
+        challenge: 'challenge',
+        consentId: 'consentId',
+        sourceAccountId: 'sourceAccountId',
+        status: 'VERIFIED',
+        value: 'value'
+      }
+    })
+
+    it('should give response properly populated from notification channel', async () => {
+      const model = await create(data, modelConfig)
+      // defer publication to notification channel
+      setImmediate(() => model.pubSub.publish(
+        channel,
+        putResponse as unknown as Message
+      ))
+      // do a request and await on published Message
+      await model.fsm.thirdpartyRequestAuthorization()
+
+      // retrieve the request
+      const result = model.getResponse()
+
+      // Assertions
+      expect(result).toEqual({
+        ...putResponse,
+        currentState: OutboundThirdpartyAuthorizationsModelState.succeeded
+      })
+      expect(mocked(modelConfig.requests.postThirdpartyRequestsTransactionsAuthorizations)).toHaveBeenCalledWith(
+        model.data.request, modelConfig.key, model.data.toParticipantId)
+      expect(mocked(modelConfig.pubSub.subscribe)).toBeCalledTimes(1)
+      expect(mocked(modelConfig.pubSub.unsubscribe)).toBeCalledWith(channel, subId)
+      expect(mocked(modelConfig.pubSub.publish)).toBeCalledWith(channel, putResponse)
+    })
+
+    it('should properly handle error from requests.postThirdpartyRequestsTransactionsAuthorizations', async () => {
+      mocked(modelConfig.requests.postThirdpartyRequestsTransactionsAuthorizations).mockImplementationOnce(
+        () => { throw new Error('error from requests.postThirdpartyRequestsTransactionsAuthorizations') }
+      )
+      const model = await create(data, modelConfig)
+
+      // do a request and await on published Message
+      try {
+        await model.fsm.thirdpartyRequestAuthorization()
+        shouldNotBeExecuted()
+      } catch (err) {
+        expect(err).toEqual(new Error('error from requests.postThirdpartyRequestsTransactionsAuthorizations'))
+        const result = model.getResponse()
+        expect(result).toBeUndefined()
+        expect(mocked(modelConfig.pubSub.subscribe)).toBeCalledTimes(1)
+        expect(mocked(modelConfig.pubSub.unsubscribe)).toBeCalledWith(channel, subId)
+      }
+    })
+
+    describe('run workflow', () => {
+      it('start', async () => {
+        const model = await create(data, modelConfig)
+
+        // defer publication to notification channel
+        setImmediate(() => model.pubSub.publish(
+          channel,
+          putResponse as unknown as Message
+        ))
+
+        const result = await model.run()
+
+        expect(result).toEqual({
+          ...putResponse,
+          currentState: OutboundThirdpartyAuthorizationsModelState.succeeded
+        })
+        expect(mocked(modelConfig.requests.postThirdpartyRequestsTransactionsAuthorizations)).toHaveBeenCalledWith(
+          model.data.request, modelConfig.key, model.data.toParticipantId)
+        expect(mocked(modelConfig.pubSub.subscribe)).toBeCalledTimes(1)
+        expect(mocked(modelConfig.pubSub.unsubscribe)).toBeCalledWith(channel, subId)
+        expect(mocked(modelConfig.pubSub.publish)).toBeCalledWith(channel, putResponse)
+
+        expect(mocked(modelConfig.logger.info)).toBeCalledWith('ThirdpartyAuthorizations completed successfully')
+        mocked(modelConfig.logger.info).mockReset()
+
+        // check retrieving state from 'succeeded'
+        expect(model.data.currentState).toEqual('succeeded')
+
+        // run workflow again
+        const newResult = await model.run()
+
+        expect(newResult).toEqual(result)
+
+        expect(mocked(modelConfig.logger.info)).toBeCalledWith('ThirdpartyAuthorizations completed successfully')
+      })
+
+      it('errored', async () => {
+
+        const model = await create({ ...data, currentState: 'errored' }, modelConfig)
+
+        const result = await model.run()
+
+        expect(mocked(modelConfig.logger.info)).toBeCalledWith('State machine in errored state')
+
+        expect(result).toBeUndefined()
+      })
+
+      it('exceptions', async () => {
+        const error = { message: 'error from requests.postThirdpartyRequestsTransactionsAuthorizations', authorizationState: 'broken' }
+        mocked(modelConfig.requests.postThirdpartyRequestsTransactionsAuthorizations).mockImplementationOnce(
+          () => {
+            throw error
+          }
+        )
+        const model = await create(data, modelConfig)
+
+        expect(async () => await model.run()).rejects.toEqual(error)
+      })
+    })
+  })
+
+  describe('loadFromKVS', () => {
+    it('should properly call `KVS.get`, get expected data in `context.data` and setup state of machine', async () => {
+      const dataFromCache: OutboundThirdpartyAuthorizationsData = {
+        toParticipantId: 'dfspA',
+        request: { mocked: true } as unknown as PostThirdpartyRequestsTransactionsAuthorizationsRequest,
+        currentState: 'succeeded'
+      }
+      mocked(modelConfig.kvs.get).mockImplementationOnce(async () => dataFromCache)
+      const am = await loadFromKVS(modelConfig)
+      checkThirdpartyAuthorizationsModelLayout(am, dataFromCache)
+
+      // to get value from cache proper key should be used
+      expect(mocked(modelConfig.kvs.get)).toHaveBeenCalledWith(modelConfig.key)
+
+      // check what has been stored in `data`
+      expect(am.data).toEqual(dataFromCache)
+    })
+
+    it('should throw when received invalid data from `KVS.get`', async () => {
+      mocked(modelConfig.kvs.get).mockImplementationOnce(async () => null)
+      try {
+        await loadFromKVS(modelConfig)
+        shouldNotBeExecuted()
+      } catch (error) {
+        expect(error.message).toEqual(`No data found in KVS for: ${modelConfig.key}`)
+      }
+    })
+
+    it('should propagate error received from `KVS.get`', async () => {
+      mocked(modelConfig.kvs.get).mockImplementationOnce(jest.fn(async () => { throw new Error('error from KVS.get') }))
+      expect(() => loadFromKVS(modelConfig))
+        .rejects.toEqual(new Error('error from KVS.get'))
+    })
+  })
+
+  describe('saveToKVS', () => {
+    it('should store using KVS.set', async () => {
+      mocked(modelConfig.kvs.set).mockImplementationOnce(() => Promise.resolve(true))
+      const data: OutboundThirdpartyAuthorizationsData = {
+        toParticipantId: 'dfspA',
+        request: { mocked: true } as unknown as PostThirdpartyRequestsTransactionsAuthorizationsRequest,
+        currentState: 'succeeded'
+      }
+
+      const model = await create(data, modelConfig)
+      checkThirdpartyAuthorizationsModelLayout(model, data)
+
+      await model.saveToKVS()
+      expect(mocked(modelConfig.kvs.set)).toBeCalledWith(model.key, model.data)
+    })
+
+    it('should propagate error from KVS.set', async () => {
+      mocked(modelConfig.kvs.set).mockImplementationOnce(() => { throw new Error('error from KVS.set') })
+      const data: OutboundThirdpartyAuthorizationsData = {
+        toParticipantId: 'dfspA',
+        request: { mocked: true } as unknown as PostThirdpartyRequestsTransactionsAuthorizationsRequest,
+        currentState: 'succeeded'
+      }
+      const am = await create(data, modelConfig)
+      checkThirdpartyAuthorizationsModelLayout(am, data)
+
+      expect(() => am.saveToKVS()).rejects.toEqual(new Error('error from KVS.set'))
+      expect(mocked(modelConfig.kvs.set)).toBeCalledWith(am.key, am.data)
+    })
+  })
+})


### PR DESCRIPTION
Closes #367 and #365

- Implement outbound **POST** `/thirdpartyRequests/transactions/{id}/authorizations` call (DFSP -> Switch)
- Implement state machine as required
- Handle inbound **PUT** `/thirdpartyRequests/transactions/{id}/authorizations`
 