### PR TITLE
fix: 1617 signchallenge uri

### DIFF
--- a/src/models/inbound/backend-requests.ts
+++ b/src/models/inbound/backend-requests.ts
@@ -25,7 +25,13 @@
  --------------
  ******/
 
-import { Logger as SDKLogger, RequestOptions, RequestResponse, request, requests } from '@mojaloop/sdk-standard-components'
+import {
+  Logger as SDKLogger,
+  RequestOptions,
+  RequestResponse,
+  request,
+  requests
+} from '@mojaloop/sdk-standard-components'
 import { AuthenticationValue, InboundAuthorizationsPostRequest } from '~/models/authorizations.interface'
 import { PrependFun, Scheme, prepend2Uri } from '~/shared/http-scheme'
 import { throwOrExtractData } from '~/shared/throw-or-extract-data'
@@ -43,6 +49,9 @@ export interface BackendConfig {
 
   // target uri for all requests
   uri: string
+
+  // the path for signAuthorizationRequest
+  singAuthorizationPath: string
 
   // should we keep alive connection with backend,
   // default 'true' if not specified
@@ -156,7 +165,7 @@ export class BackendRequests {
     inRequest: InboundAuthorizationsPostRequest
   ): Promise<AuthenticationValue | void> {
     return this.post<InboundAuthorizationsPostRequest, AuthenticationValue>(
-      'signchallenge', inRequest
+      this.config.singAuthorizationPath, inRequest
     )
   }
 }

--- a/src/models/inbound/backend-requests.ts
+++ b/src/models/inbound/backend-requests.ts
@@ -156,7 +156,7 @@ export class BackendRequests {
     inRequest: InboundAuthorizationsPostRequest
   ): Promise<AuthenticationValue | void> {
     return this.post<InboundAuthorizationsPostRequest, AuthenticationValue>(
-      this.fullUri('signAuthorizationRequest'), inRequest
+      'signchallenge', inRequest
     )
   }
 }

--- a/src/server/plugins/state.ts
+++ b/src/server/plugins/state.ts
@@ -110,7 +110,8 @@ export const StatePlugin = {
       logger,
       dfspId: config.SHARED.DFSP_ID,
       uri: config.SHARED.DFSP_BACKEND_URI,
-      scheme: config.SHARED.DFSP_BACKEND_HTTP_SCHEME as Scheme
+      scheme: config.SHARED.DFSP_BACKEND_HTTP_SCHEME as Scheme,
+      singAuthorizationPath: config.SHARED.DFSP_BACKEND_SIGN_AUTHORIZATION_PATH
     })
 
     try {

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -78,6 +78,7 @@ export interface ServiceConfig {
     BULK_TRANSFERS_ENDPOINT: string
     DFSP_ID: string
     DFSP_BACKEND_URI: string
+    DFSP_BACKEND_SIGN_AUTHORIZATION_PATH: string
     DFSP_BACKEND_HTTP_SCHEME: string
     JWS_SIGN: boolean
     JWS_SIGNING_KEY: PathLike | Buffer
@@ -234,9 +235,14 @@ export const ConvictConfig = Convict<ServiceConfig>({
       default: 'dfsp_a'
     },
     DFSP_BACKEND_URI: {
-      doc: 'host/path address of DFSP\'s ',
+      doc: 'host address of DFSP\'s ',
       format: '*',
       default: 'localhost:9000'
+    },
+    DFSP_BACKEND_SIGN_AUTHORIZATION_PATH: {
+      doc: 'path use by BackendRequests.signAuthorizationRequest',
+      format: '*',
+      default: 'signchallenge'
     },
     DFSP_BACKEND_HTTP_SCHEME: {
       doc: 'Http scheme ',

--- a/test/unit/models/inbound/backend-requests.test.ts
+++ b/test/unit/models/inbound/backend-requests.test.ts
@@ -40,7 +40,8 @@ describe('backendRequests', () => {
     dfspId: 'the-dfsp-id',
     logger: mockLogger(),
     scheme: Scheme.http,
-    uri: 'backend-uri'
+    uri: 'backend-uri',
+    singAuthorizationPath: 'singchallenge'
   }
 
   const headers = {
@@ -223,7 +224,7 @@ describe('backendRequests', () => {
       )
       const result = await backendRequests.signAuthorizationRequest(authorizationsPostRequest)
       expect(result).toEqual(authenticationValue)
-      expect(postSpy).toBeCalledWith('signchallenge', authorizationsPostRequest)
+      expect(postSpy).toBeCalledWith(config.singAuthorizationPath, authorizationsPostRequest)
     })
   })
 })

--- a/test/unit/models/inbound/backend-requests.test.ts
+++ b/test/unit/models/inbound/backend-requests.test.ts
@@ -223,7 +223,7 @@ describe('backendRequests', () => {
       )
       const result = await backendRequests.signAuthorizationRequest(authorizationsPostRequest)
       expect(result).toEqual(authenticationValue)
-      expect(postSpy).toBeCalledWith('http://backend-uri/signAuthorizationRequest', authorizationsPostRequest)
+      expect(postSpy).toBeCalledWith('signchallenge', authorizationsPostRequest)
     })
   })
 })


### PR DESCRIPTION
`/signchallenge` endpoint is already implemented in mojaloop-simulator https://github.com/mojaloop/mojaloop-simulator/blob/pisp/master/src/simulator/api.yaml#L219. 

there not flexible to have it hardcoded so I migrated this path to configuration