### PR TITLE
fix: quote request `note` field

### DIFF
--- a/src/domain/thirdpartyRequests/transactions.ts
+++ b/src/domain/thirdpartyRequests/transactions.ts
@@ -33,7 +33,6 @@ export function buildPayeeQuoteRequestFromTptRequest (request: ThirdpartyTransac
   const quoteRequest = {
     quoteId: uuid(),
     transactionId: uuid(),
-    note: '',
     transactionRequestId: request.transactionRequestId,
     payee: request.payee,
     payer: request.payer,

--- a/src/interface/types.ts
+++ b/src/interface/types.ts
@@ -113,7 +113,7 @@ export interface QuoteRequest {
   amountType: AmountType;
   amount: Money;
   transactionType: TransactionType;
-  note: string;
+  note?: string;
 }
 
 export interface HealthResponse {

--- a/test/unit/domain/thirdpartyRequests.test.ts
+++ b/test/unit/domain/thirdpartyRequests.test.ts
@@ -79,7 +79,7 @@ describe.only('thirdpartyRequests/transactions', (): void => {
       postThirdpartyRequestsTransactionRequest.payload
     )
 
-    // resetUuid()
+    resetUuid()
 
     forwardPostQuoteRequestToPayee(
       postThirdpartyRequestsTransactionRequest.payload,

--- a/test/unit/domain/thirdpartyRequests.test.ts
+++ b/test/unit/domain/thirdpartyRequests.test.ts
@@ -49,7 +49,7 @@ jest.mock('@mojaloop/sdk-standard-components', () => {
   }
 })
 
-describe('thirdpartyRequests/transactions', (): void => {
+describe.only('thirdpartyRequests/transactions', (): void => {
   beforeEach((): void => {
     jest.clearAllMocks()
     resetUuid()
@@ -63,7 +63,6 @@ describe('thirdpartyRequests/transactions', (): void => {
     expectMockQuoteRequest.toEqual(expect.objectContaining({
       quoteId: '00000000-0000-1000-8000-000000000001',
       transactionId: '00000000-0000-1000-8000-000000000002',
-      note: ''
     }))
     expectMockQuoteRequest.toEqual(expect.objectContaining({
       payee: postQuoteRequest.payload.payee,
@@ -80,7 +79,7 @@ describe('thirdpartyRequests/transactions', (): void => {
       postThirdpartyRequestsTransactionRequest.payload
     )
 
-    resetUuid()
+    // resetUuid()
 
     forwardPostQuoteRequestToPayee(
       postThirdpartyRequestsTransactionRequest.payload,

--- a/test/unit/domain/thirdpartyRequests.test.ts
+++ b/test/unit/domain/thirdpartyRequests.test.ts
@@ -49,7 +49,7 @@ jest.mock('@mojaloop/sdk-standard-components', () => {
   }
 })
 
-describe.only('thirdpartyRequests/transactions', (): void => {
+describe('thirdpartyRequests/transactions', (): void => {
   beforeEach((): void => {
     jest.clearAllMocks()
     resetUuid()


### PR DESCRIPTION
- Addresses an issue where we created an quote with a empty `note` string. The sdk-scheme-adapter inbound didn't like this, but since note is not required, I simply removed it for now. In the future, we could add `note` to the `ThirdpartyTransactionRequest` body, if we wish to expose it to end users.