### PR TITLE
ci: add build-local dep to publish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -614,6 +614,7 @@ workflows:
             # - image-scan
             - test-unit
             - test-coverage
+            - build-local
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
build-local is providing docker-image.tar which is required by publish