### PR TITLE
chore: modify outbound accounts endpoint path

### DIFF
--- a/src/handlers/outbound/accounts/{fspId}/{userId}.ts
+++ b/src/handlers/outbound/accounts/{fspId}/{userId}.ts
@@ -35,15 +35,15 @@ import {
 } from '~/models/outbound/accounts.model'
 
 /**
- * Handles outbound GET /accounts/{ID} request
+ * Handles outbound GET /accounts/{fspId}/{userId} request
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function get (_context: any, request: Request, h: StateResponseToolkit): Promise<ResponseObject> {
 
-  const userId: string = request.params.ID
+  const userId: string = request.params.userId
   // prepare config
   const data: OutboundAccountsData = {
-    toParticipantId: request.headers['fspiop-destination'],
+    toParticipantId: request.params.fspId,
     userId: userId,
     currentState: 'start'
   }

--- a/src/handlers/outbound/index.ts
+++ b/src/handlers/outbound/index.ts
@@ -31,7 +31,7 @@ import ThirdpartyAuthorizations from './thirdpartyRequests/transactions/{ID}/aut
 import ThirdpartyTransactionPartyLookup from './thirdpartyTransaction/partyLookup'
 import ThirdpartyTransactionInitiate from './thirdpartyTransaction/{ID}/initiate'
 import ThirdpartyTransactionApprove from './thirdpartyTransaction/{ID}/approve'
-import Accounts from './accounts/{ID}'
+import Accounts from './accounts/{fspId}/{userId}'
 
 export default {
   OutboundAuthorizationsPost: Authorizations.post,

--- a/src/interface/api-outbound.yaml
+++ b/src/interface/api-outbound.yaml
@@ -253,19 +253,26 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  '/accounts/{ID}':
+  '/accounts/{fspId}/{userId}':
     get:
       operationId: GetAccountsByUserId
       summary: GetAccountsByUserId
       description: >
-        The HTTP request `GET /accounts/{ID}` is used to retrieve the list of
-        potential accounts available for linking.
+        The HTTP request `GET /accounts/{fspId}/{userId}` is used to retrieve
+        the list of potential accounts available for linking.
       tags:
         - accounts
       parameters:
-        - $ref: '#/components/parameters/ID'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - name: fspId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/FspId'
+        - name: userId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/AccountAddress'
       responses:
         '200':
           $ref: '#/components/responses/AccountsByUserIdResponse'
@@ -1619,29 +1626,3 @@ components:
       schema:
         type: string
       description: The identifier value.
-    FSPIOP-Source:
-      name: FSPIOP-Source
-      in: header
-      schema:
-        type: string
-      required: true
-      description: >-
-        The `FSPIOP-Source` header field is a non-HTTP standard field used by
-        the API for identifying the sender of the HTTP request. The field should
-        be set by the original sender of the request. Required for routing and
-        signature verification (see header field `FSPIOP-Signature`).
-    FSPIOP-Destination:
-      name: FSPIOP-Destination
-      in: header
-      schema:
-        type: string
-      required: false
-      description: >-
-        The `FSPIOP-Destination` header field is a non-HTTP standard field used
-        by the API for HTTP header based routing of requests and responses to
-        the destination. The field must be set by the original sender of the
-        request if the destination is known (valid for all services except GET
-        /parties) so that any entities between the client and the server do not
-        need to parse the payload for routing purposes. If the destination is
-        not known (valid for service GET /parties), the field should be left
-        empty.

--- a/src/interface/outbound/api_interfaces/openapi.d.ts
+++ b/src/interface/outbound/api_interfaces/openapi.d.ts
@@ -25,7 +25,7 @@ export interface paths {
   "/thirdpartyRequests/transactions/{ID}/authorizations": {
     post: operations["VerifyThirdPartyAuthorization"];
   };
-  "/accounts/{ID}": {
+  "/accounts/{fspId}/{userId}": {
     get: operations["GetAccountsByUserId"];
   };
 }
@@ -159,15 +159,12 @@ export interface operations {
       503: components["responses"]["503"];
     };
   };
-  /** The HTTP request `GET /accounts/{ID}` is used to retrieve the list of potential accounts available for linking. */
+  /** The HTTP request `GET /accounts/{fspId}/{userId}` is used to retrieve the list of potential accounts available for linking. */
   GetAccountsByUserId: {
     parameters: {
       path: {
-        ID: components["parameters"]["ID"];
-      };
-      header: {
-        "FSPIOP-Source": components["parameters"]["FSPIOP-Source"];
-        "FSPIOP-Destination"?: components["parameters"]["FSPIOP-Destination"];
+        fspId: components["schemas"]["FspId"];
+        userId: components["schemas"]["AccountAddress"];
       };
     };
     responses: {
@@ -188,10 +185,6 @@ export interface components {
   parameters: {
     /** The identifier value. */
     ID: string;
-    /** The `FSPIOP-Source` header field is a non-HTTP standard field used by the API for identifying the sender of the HTTP request. The field should be set by the original sender of the request. Required for routing and signature verification (see header field `FSPIOP-Signature`). */
-    "FSPIOP-Source": string;
-    /** The `FSPIOP-Destination` header field is a non-HTTP standard field used by the API for HTTP header based routing of requests and responses to the destination. The field must be set by the original sender of the request if the destination is known (valid for all services except GET /parties) so that any entities between the client and the server do not need to parse the payload for routing purposes. If the destination is not known (valid for service GET /parties), the field should be left empty. */
-    "FSPIOP-Destination": string;
   };
   schemas: {
     /** The API data type ErrorCode is a JSON String of four characters, consisting of digits only. Negative numbers are not allowed. A leading zero is not allowed. Each error code in the API is a four-digit number, for example, 1234, where the first number (1 in the example) represents the high-level error category, the second number (2 in the example) represents the low-level error category, and the last two numbers (34 in the example) represent the specific error. */

--- a/src/interface/outbound/api_template/api-outbound-template.yaml
+++ b/src/interface/outbound/api_template/api-outbound-template.yaml
@@ -29,5 +29,5 @@ paths:
     $ref: paths/thirdpartyTransaction_approve.yaml
   '/thirdpartyRequests/transactions/{ID}/authorizations':
     $ref: paths/thirdpartyRequests_transactions_ID_authorizations.yaml
-  '/accounts/{ID}':
+  '/accounts/{fspId}/{userId}':
     $ref: paths/accounts_ID.yaml

--- a/src/interface/outbound/api_template/paths/accounts_ID.yaml
+++ b/src/interface/outbound/api_template/paths/accounts_ID.yaml
@@ -2,15 +2,20 @@ get:
   operationId: GetAccountsByUserId
   summary: GetAccountsByUserId
   description: |
-    The HTTP request `GET /accounts/{ID}` is used to retrieve the list of potential accounts available for linking.
+    The HTTP request `GET /accounts/{fspId}/{userId}` is used to retrieve the list of potential accounts available for linking.
   tags:
     - accounts
   parameters:
-  #Path
-  - $ref: '../../../../../node_modules/@mojaloop/api-snippets/fspiop/v1_1/openapi3/components/parameters/ID.yaml'
-  #Headers
-  - $ref: '../../../../../node_modules/@mojaloop/api-snippets/fspiop/v1_1/openapi3/components/parameters/FSPIOP-Source.yaml'
-  - $ref: '../../../../../node_modules/@mojaloop/api-snippets/fspiop/v1_1/openapi3/components/parameters/FSPIOP-Destination.yaml'
+    - name: fspId
+      in: path
+      required: true
+      schema:
+        $ref: '../../../../../node_modules/@mojaloop/api-snippets/fspiop/v1_1/openapi3/components/schemas/FspId.yaml'
+    - name: userId
+      in: path
+      required: true
+      schema:
+        $ref: '../../../../../node_modules/@mojaloop/api-snippets/thirdparty/openapi3/components/schemas/AccountAddress.yaml'
   responses:
     '200':
       $ref: '../components/responses/AccountsByUserIdResponse.yaml'

--- a/test/integration/outbound/accounts.test.ts
+++ b/test/integration/outbound/accounts.test.ts
@@ -27,15 +27,7 @@
 
 import axios from 'axios'
 
-describe('GET /accounts/{ID}', (): void => {
-  const scenariosURI = `http://127.0.0.1:4056/accounts/username1234`
-  const requestConfig = {
-    headers: {
-      'FSPIOP-Source': 'pisp',
-      'FSPIOP-Destination': 'dfspA',
-      Date: new Date().toUTCString()
-    }
-  }
+describe('GET /accounts/{fspId}/{userId}', (): void => {
   const expectedResp = {
     accounts: [
       {
@@ -53,8 +45,9 @@ describe('GET /accounts/{ID}', (): void => {
   }
 
   it('PISP requests DFSP to return user accounts for linking', async (): Promise<void> => {
+    const scenariosURI = `http://127.0.0.1:4006/accounts/dfspa/username1234`
     // Act
-    const response = await axios.get(scenariosURI, requestConfig)
+    const response = await axios.get(scenariosURI)
 
     // Assert
     expect(response.status).toBe(200)
@@ -62,5 +55,24 @@ describe('GET /accounts/{ID}', (): void => {
 
     // Assert state machine state
     expect(response.data.currentState).toEqual('COMPLETED')
+  })
+
+  it('PISP requests DFSP: Expect ID not found', async (): Promise<void> => {
+    const scenariosURI = `http://127.0.0.1:4006/accounts/dfspa/test`
+    const idNotFoundResp = {
+      accounts: [],
+      errorInformation: {
+        errorCode: '3200',
+        errorDescription: 'Generic ID not found'
+      },
+      currentState: 'COMPLETED'
+    }
+
+    await axios.get(scenariosURI)
+      .catch(error => {
+        // Assert
+        expect(error.response.status).toBe(500)
+        expect(error.response.data).toEqual(expect.objectContaining(idNotFoundResp))
+      })
   })
 })

--- a/test/unit/handlers/outbound-api.test.ts
+++ b/test/unit/handlers/outbound-api.test.ts
@@ -450,14 +450,10 @@ describe('Outbound API routes', (): void => {
     })
   })
 
-  it('/accounts/{ID} -success', async (): Promise<void> => {
+  it('/accounts/{fspId}/{userId} -success', async (): Promise<void> => {
     const request = {
       method: 'GET',
-      url: '/accounts/username1234',
-      headers: {
-        'FSPIOP-Source': 'pisp',
-        'FSPIOP-Destination': 'dfspA',
-      }
+      url: '/accounts/dfspa/username1234',
     }
     const pubSub = new PubSub({} as RedisConnectionConfig)
     // defer publication to notification channel
@@ -484,19 +480,15 @@ describe('Outbound API routes', (): void => {
     }
     expect((response.result)).toEqual(expectedResp)
   }),
-    it('/accounts/{ID} -fail', async (): Promise<void> => {
+    it('/accounts/{fspId}/{userId} -fail', async (): Promise<void> => {
       const request = {
         method: 'GET',
-        url: '/accounts/username1234',
-        headers: {
-          'FSPIOP-Source': 'pisp',
-          'FSPIOP-Destination': 'dfspA',
-        }
+        url: '/accounts/dfspa/test'
       }
       const errorResp = {
-        "errorInformation": {
-          "errorCode": "3200",
-          "errorDescription": "Generic ID not found"
+        errorInformation: {
+          errorCode: "3200",
+          errorDescription: "Generic ID not found"
         }
       }
       const pubSub = new PubSub({} as RedisConnectionConfig)


### PR DESCRIPTION
destination fspId moved from headers to path params
path: `GET /accounts/{ID}` changed  to `GET /accounts/{fspId}/{userId}`