### PR TITLE
feat(backend-requests): store consent request id with consent

### DIFF
--- a/src/models/inbound/dfspLinking.interface.ts
+++ b/src/models/inbound/dfspLinking.interface.ts
@@ -84,6 +84,7 @@ export interface BackendGetScopesResponse {
 export interface BackendStoreValidatedConsentRequest {
   scopes: tpAPI.Schemas.Scope[]
   consentId: string
+  consentRequestId: string
   registrationChallenge: string
   credential: tpAPI.Schemas.VerifiedCredential
 }

--- a/src/models/inbound/dfspLinking.model.ts
+++ b/src/models/inbound/dfspLinking.model.ts
@@ -531,6 +531,7 @@ export class DFSPLinkingModel
     const {
       consentIDPutResponseFromAuthService,
       consentId,
+      consentRequestId,
       consentPostRequestToAuthService
     } = this.data
 
@@ -538,6 +539,7 @@ export class DFSPLinkingModel
       await this.dfspBackendRequests.storeValidatedConsentForAccountId(
         consentIDPutResponseFromAuthService!.scopes,
         consentId!,
+        consentRequestId,
         DFSPLinkingModel.deriveChallenge(consentPostRequestToAuthService!),
         consentIDPutResponseFromAuthService!.credential
       )

--- a/src/shared/dfsp-backend-requests.ts
+++ b/src/shared/dfsp-backend-requests.ts
@@ -184,12 +184,14 @@ export class DFSPBackendRequests extends HttpRequests {
   async storeValidatedConsentForAccountId (
     scopes: tpAPI.Schemas.Scope[],
     consentId: string,
+    consentRequestId: string,
     registrationChallenge: string,
     credential: tpAPI.Schemas.VerifiedCredential
   ): Promise<void> {
     const validatedConsent: BackendStoreValidatedConsentRequest = {
-      scopes: scopes,
+      scopes,
       consentId,
+      consentRequestId,
       registrationChallenge,
       credential
     }

--- a/test/unit/models/inbound/dfspLinking.model.test.ts
+++ b/test/unit/models/inbound/dfspLinking.model.test.ts
@@ -1202,6 +1202,7 @@ describe('dfspLinkingModel', () => {
             }
           ],
           "00000000-0000-1000-8000-000000000001",
+          "b51ec534-ee48-4575-b6a9-ead2955b8069",
           "b9c285afee7a671a42b0f9276e6d90f7e21c1e56f4c73a5200fe708850149eea",
           {
             credentialType: 'FIDO',

--- a/test/unit/shared/dfsp-backend-requests.test.ts
+++ b/test/unit/shared/dfsp-backend-requests.test.ts
@@ -238,6 +238,7 @@ describe('backendRequests', () => {
           }
         ],
         'ced49ef2-2393-46e3-a6e5-527d64e61eab',
+        'b51ec534-ee48-4575-b6a9-ead2955b8069',
         'c4adabb33e9306b038088132affcde556c50d82f603f47711a9510bf3beef6d6',
         {
           "credentialType": "FIDO",
@@ -283,6 +284,7 @@ describe('backendRequests', () => {
         ],
         consentId: 'ced49ef2-2393-46e3-a6e5-527d64e61eab',
         registrationChallenge: 'c4adabb33e9306b038088132affcde556c50d82f603f47711a9510bf3beef6d6',
+        consentRequestId: 'b51ec534-ee48-4575-b6a9-ead2955b8069',
         credential: {
           "credentialType": "FIDO",
           "status": "VERIFIED",


### PR DESCRIPTION
Oops, forgot about this as well... we need a way to relate a finalized consent with the consentRequest in the dfsp's backend